### PR TITLE
Fix: querystring ampersand handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "uniloc-clebert-fork",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Universal JavaScript Route Parsing and Generation in 1.3KB compressed/minified",
   "main": "uniloc.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -99,3 +99,40 @@ test('lookup() should strip fragment identifier', (t) => {
     }
   })
 })
+
+test('lookup() should accept a leading ampersand in query string', (t) => {
+  const router = t.context.router
+
+  t.deepEqual(router.lookup('/contacts/13/edit/?&details=true#foo'), {
+    name: 'editContact',
+    options: {
+      id: '13',
+      details: 'true'
+    }
+  })
+})
+
+test('lookup() should accept a trailing ampersand in query string', (t) => {
+  const router = t.context.router
+
+  t.deepEqual(router.lookup('/contacts/13/edit/?details=true&'), {
+    name: 'editContact',
+    options: {
+      id: '13',
+      details: 'true'
+    }
+  })
+})
+
+test('lookup() should accept double ampersands in query string', (t) => {
+  const router = t.context.router
+
+  t.deepEqual(router.lookup('/contacts/13/edit/?details=true&&foo=bar'), {
+    name: 'editContact',
+    options: {
+      id: '13',
+      details: 'true',
+      foo: 'bar'
+    }
+  })
+})

--- a/uniloc.js
+++ b/uniloc.js
@@ -158,8 +158,11 @@
 
         params = routesParams[name] || []
 
+        var removeEmptyParams = function (p) {
+          return p && (typeof(p) === 'string' || p instanceof String) && p.length > 0
+        }
         var query = split[1] || ''
-        queryParts = query ? query.split('&') : []
+        queryParts = query ? query.split('&').filter(removeEmptyParams) : []
 
         for (i = 0; i !== queryParts.length; i++) {
           x = queryParts[i].split('=')


### PR DESCRIPTION
Trailing and/or leading ampersands as well as double ampersands (`&&`) will cause an assertion. Since `&` is allowed anywhere within the querystring, this behaviour should be fixed.